### PR TITLE
백준 1008번

### DIFF
--- a/백준 1008번
+++ b/백준 1008번
@@ -1,0 +1,15 @@
+#include <iostream> 
+
+using namespace std;
+
+int main() { 
+	double a, b;
+	cin >> a >> b;
+
+	cout.precision(9);
+
+	cout << fixed;
+	cout << a / b;
+
+	return 0;
+}


### PR DESCRIPTION
실제 정답과 출력값의 절대오차 또는 상대오차가 10-9 이하이면 정답. ->오차 범위'가 10-9 이하여야 하기 때문에 출력 할 때도 출력할 소수점 자리를 9개 이상 출력하도록 해야한다. float 10^(-7)까지, double 10^(-15)까지라서 double을 사용.